### PR TITLE
fix: harden xMatters request and token handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.8
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2017-2025 Splunk Inc.
+   Copyright (c) 2017-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: xMatters for SOAR
-Copyright (c) 2017-2025 Splunk Inc.
+Copyright (c) 2017-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,5 @@
 # File: __init__.py
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Safely constrain xMatters API path and pagination inputs.
+* Encrypt cached xMatters OAuth tokens in connector state.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Update development tooling.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Update development tooling.
+* Safely constrain xMatters API path and pagination inputs.

--- a/xmatters.json
+++ b/xmatters.json
@@ -15,7 +15,7 @@
     "fips_compliant": true,
     "logo": "logo_xmatters.svg",
     "logo_dark": "logo_xmatters_dark.svg",
-    "license": "Copyright (c) 2017-2025 Splunk Inc.",
+    "license": "Copyright (c) 2017-2026 Splunk Inc.",
     "python_version": "3.9, 3.13",
     "latest_tested_versions": [
         "api v1 tested on 3 January, 2022"

--- a/xmatters_connector.py
+++ b/xmatters_connector.py
@@ -88,6 +88,18 @@ class XMattersConnector(BaseConnector):
         self.save_state(self._state)
         return phantom.APP_SUCCESS
 
+    def _get_page_endpoint(self, action_result, page_uri, expected_path):
+        page = urllib.parse.urlsplit(page_uri)
+        base = urllib.parse.urlsplit(self._base_url)
+        if page.scheme or page.netloc:
+            if (page.scheme, page.netloc) != (base.scheme, base.netloc):
+                action_result.set_status(phantom.APP_ERROR, "Pagination link must use the configured xMatters API origin")
+                return None
+        if not page.path.startswith(expected_path) or any(part in (".", "..") for part in page.path.split("/")):
+            action_result.set_status(phantom.APP_ERROR, "Invalid xMatters pagination link")
+            return None
+        return urllib.parse.urlunsplit(("", "", page.path, page.query, ""))
+
     def _get_error_message_from_exception(self, e):
         """This method is used to get appropriate error message from the exception.
         :param e: Exception object
@@ -344,7 +356,9 @@ class XMattersConnector(BaseConnector):
 
         # Prefer the next page if provided
         try:
-            endpoint = param["page_uri"]
+            endpoint = self._get_page_endpoint(action_result, param["page_uri"], XM_ENDPOINT_LIST_EVENTS)
+            if endpoint is None:
+                return action_result.get_status()
         except KeyError:
             for k, v in param.items():
                 if k == "context":
@@ -389,7 +403,7 @@ class XMattersConnector(BaseConnector):
             if k == "context":
                 continue
             elif k == "form_uuid":
-                endpoint = endpoint.format(v)
+                endpoint = endpoint.format(urllib.parse.quote(str(v), safe=""))
             elif k == "recipients":
                 tnames = v.split(",")
                 recipients = [{"targetName": x.strip()} for x in tnames]
@@ -421,7 +435,7 @@ class XMattersConnector(BaseConnector):
         params = {}
 
         event_id = param["event_id"]
-        endpoint = XM_ENDPOINT_GET_EVENT.format(event_id)
+        endpoint = XM_ENDPOINT_GET_EVENT.format(urllib.parse.quote(str(event_id), safe=""))
 
         ret_val, auth, headers = self._get_authorization_credentials(action_result)
         if phantom.is_fail(ret_val):
@@ -482,7 +496,9 @@ class XMattersConnector(BaseConnector):
             return ret_val
 
         try:
-            endpoint = param["page_uri"]
+            endpoint = self._get_page_endpoint(action_result, param["page_uri"], XM_ENDPOINT_LIST_PEOPLE)
+            if endpoint is None:
+                return action_result.get_status()
         except KeyError:
             regex = re.compile(r",\s+")
             for k, v in param.items():
@@ -515,7 +531,7 @@ class XMattersConnector(BaseConnector):
         params = {}
 
         person_id = param["identifier"]
-        endpoint = XM_ENDPOINT_GET_PEOPLE.format(person_id)
+        endpoint = XM_ENDPOINT_GET_PEOPLE.format(urllib.parse.quote(str(person_id), safe=""))
 
         ret_val, auth, headers = self._get_authorization_credentials(action_result)
         if phantom.is_fail(ret_val):

--- a/xmatters_connector.py
+++ b/xmatters_connector.py
@@ -18,6 +18,8 @@ import urllib.parse
 import urllib.request
 from datetime import datetime
 
+import encryption_helper
+
 # Phantom Imports
 import phantom.app as phantom
 
@@ -82,9 +84,20 @@ class XMattersConnector(BaseConnector):
             self._use_token = True
 
         self._state = self.load_state()
+        token = self._state.get("oauth_token")
+        if isinstance(token, str):
+            try:
+                self._state["oauth_token"] = json.loads(encryption_helper.decrypt(token, self.get_asset_id()))
+            except Exception:
+                self.debug_print("Unable to decrypt cached OAuth token; requesting a new token")
+                self._state.pop("oauth_token", None)
+                self._state.pop("retrieval_time", None)
         return phantom.APP_SUCCESS
 
     def finalize(self):
+        token = self._state.get("oauth_token")
+        if isinstance(token, dict):
+            self._state["oauth_token"] = encryption_helper.encrypt(json.dumps(token), self.get_asset_id())
         self.save_state(self._state)
         return phantom.APP_SUCCESS
 

--- a/xmatters_connector.py
+++ b/xmatters_connector.py
@@ -1,5 +1,5 @@
 # File: xmatters_connector.py
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xmatters_consts.py
+++ b/xmatters_consts.py
@@ -1,5 +1,5 @@
 # File: xmatters_consts.py
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xmatters_get_oncall_user.html
+++ b/xmatters_get_oncall_user.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: xmatters_get_oncall_user.html
-  Copyright (c) 2017-2025 Splunk Inc.
+  Copyright (c) 2017-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xmatters_view.py
+++ b/xmatters_view.py
@@ -1,6 +1,6 @@
 # File: xmatters_view.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Bug Fixes

- PSAAS-31265: encode xMatters path parameters and constrain pagination links to the configured collection origin.
- PSAAS-31402: encrypt cached OAuth access and refresh tokens before state persistence.

### Manual Documentation

- [x] No `manual_readme_content.md` change is needed; this hardens existing request and token handling.

### Other information

- Legacy plaintext OAuth state remains usable for one run and is encrypted on finalize; failed decryption safely reauthenticates.
- Validated with Python compilation and the full refreshed v2.2.4 pre-commit suite.
- Tracking: PAPP-38114; PSAAS-31265 and PSAAS-31402.

Written by Codex.